### PR TITLE
Cache Gradle distributions in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,7 +17,21 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - uses: gradle/actions/setup-gradle@v6
+      # Anchored so the Windows job can reuse this step verbatim via *setup-gradle.
+      - &setup-gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          # "caches" and "notifications" are the action's defaults and have to be repeated here. "wrapper" additionally
+          # caches the Gradle distributions under wrapper/dists. The teamscale-gradle-plugin tests run against
+          # MINIMUM_SUPPORTED_VERSION via TestKit, so without this every build re-downloads that distribution
+          # (~145 MB) from services.gradle.org, which has made builds fail when that server was unavailable.
+          # The "-all" distribution used by our own wrapper is excluded because it alone would add ~570 MB.
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            wrapper
+          gradle-home-cache-excludes: |
+            wrapper/dists/gradle-*-all
       - name: Build with Gradle
         run: ./gradlew build
       - name: Upload Release Assets
@@ -78,7 +92,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - uses: gradle/actions/setup-gradle@v6
+      - *setup-gradle
       - name: Build with Gradle
         run: ./gradlew build --max-workers=2
       - name: Upload coverage to Teamscale


### PR DESCRIPTION
## Problem

The `v37.0.2` tag build [failed](https://github.com/cqse/teamscale-java-profiler/actions/runs/31152714950) on the Windows job. All ~24 failing `teamscale-gradle-plugin` tests shared one root cause:

```
java.io.IOException: Server returned HTTP response code: 502 for URL:
https://services.gradle.org/distributions/gradle-8.10-bin.zip
```

The plugin tests run against `TeamscalePlugin.MINIMUM_SUPPORTED_VERSION` via `GradleRunner#withGradleVersion`, so TestKit downloads that Gradle distribution at test runtime. `gradle/actions/setup-gradle` caches only `caches` and `notifications` from `GRADLE_USER_HOME` by default — `wrapper` is not included — so this ~145 MB download happened on **every** build, on every OS, with `services.gradle.org` as a single point of failure.

The same applies to our own wrapper distribution: a run with a warm cache and an unchanged Gradle version still re-downloaded `gradle-9.6.1-all.zip` on both jobs.

## Change

Add `wrapper` to `gradle-home-cache-includes`, so the distributions under `wrapper/dists` are cached.

`wrapper/dists/gradle-*-all` is excluded: the `-all` distribution used by our own wrapper is ~570 MB on its own, versus ~145 MB for the `-bin` one TestKit needs. Excluding it keeps the cache entry reasonable and leaves the wrapper download exactly as it is today.

The step is identical in both jobs, so it is shared with a YAML anchor (`&setup-gradle` / `*setup-gradle`). GitHub Actions has supported anchors [since September 2025](https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/); only merge keys are unsupported, which aliasing a whole step does not need.

## Notes

- `cache-read-only: true` on tag and PR builds means only a build on `master` writes the cache, so the first run after merge primes the entry and later runs benefit.
- Verified locally that the distribution lands in `GRADLE_USER_HOME/wrapper/dists` (not in a temp directory as I first assumed): with both candidate locations deleted, `gradle-8.10-bin` reappeared under `~/.gradle/wrapper/dists`.
- Verified the anchor resolves to identical step maps in both jobs, with step counts unchanged.
- No CHANGELOG entry — CI-only change with no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)