### PR TITLE
TS-47301 Make the result mandatory, log warnings if a duration cannot be derived automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ We use [semantic versioning](http://semver.org/):
 
 # Next version
 - [breaking] _agent_: Log lines now show the simple class name (`INFO Agent - ...`) instead of the fully qualified one.
+- [breaking] _agent_: In testwise coverage mode, the test result is now mandatory in the body of `/test/end` requests. Requests without a result (or without a body at all) are rejected with "400 Bad Request" instead of silently producing a report entry without a result. The duration remains optional: if it is omitted, the profiler derives it from the time between the `/test/start` and `/test/end` requests. The profiler additionally logs a warning if no `/test/start` request was received, since the duration cannot be derived reliably in that case.
+- [breaking] _tia-client_: Removed the `ITestwiseCoverageAgentApi.testFinished(testUniformPath)` overload, which sent a `/test/end` request without a body. Since the agent now rejects such requests, use `testFinished(testUniformPath, testExecution)` instead.
+- [fix] _agent_: A test whose result the profiler does not know is now reported as `INCONCLUSIVE` instead of `SKIPPED`. This affects tests that are ended implicitly because the next `/test/start` arrived before their `/test/end`, or because the test run ended while the tests were still running.
+- [fix] _agent_: Requests to the profiler's REST API that are rejected as invalid (e.g. a `/test/start` without a test name or an empty `PUT /partition` body) now respond with the appropriate HTTP status code, e.g. "400 Bad Request".
 
 # 37.0.2
 - [fix] _agent_: In some cases the hostname was wrongly added to the PID when sending it to Teamscale.

--- a/agent/src/main/kotlin/com/teamscale/jacoco/agent/GenericExceptionMapper.kt
+++ b/agent/src/main/kotlin/com/teamscale/jacoco/agent/GenericExceptionMapper.kt
@@ -1,5 +1,6 @@
 package com.teamscale.jacoco.agent
 
+import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper
@@ -10,9 +11,11 @@ import javax.ws.rs.ext.Provider
  */
 @Provider
 class GenericExceptionMapper : ExceptionMapper<Throwable?> {
-	override fun toResponse(e: Throwable?): Response =
-		Response.status(Response.Status.INTERNAL_SERVER_ERROR).apply {
+	override fun toResponse(e: Throwable?): Response {
+		val status = (e as? WebApplicationException)?.response?.statusInfo ?: Response.Status.INTERNAL_SERVER_ERROR
+		return Response.status(status).apply {
 			type(MediaType.TEXT_PLAIN_TYPE)
 			entity("Message: ${e?.message}")
 		}.build()
+	}
 }

--- a/agent/src/main/kotlin/com/teamscale/jacoco/agent/ResourceBase.kt
+++ b/agent/src/main/kotlin/com/teamscale/jacoco/agent/ResourceBase.kt
@@ -114,11 +114,11 @@ abstract class ResourceBase(protected val agentBase: AgentBase) {
 		}
 
 	/**
-	 * Handles bad requests to the endpoints.
+	 * Handles bad requests to the endpoints. Never returns normally, it always throws a [BadRequestException].
 	 */
 	@Contract(value = "_ -> fail")
 	@Throws(BadRequestException::class)
-	protected fun handleBadRequest(message: String?) {
+	protected fun handleBadRequest(message: String?): Nothing {
 		logger.error(message)
 		throw BadRequestException(message)
 	}

--- a/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/CoverageToExecFileStrategy.kt
+++ b/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/CoverageToExecFileStrategy.kt
@@ -16,14 +16,14 @@ import java.io.IOException
 class CoverageToExecFileStrategy(
 	controller: JacocoRuntimeController, agentOptions: AgentOptions,
 	/** Helper for writing test executions to disk.  */
-	private val testExecutionWriter: TestExecutionWriter?
+	private val testExecutionWriter: TestExecutionWriter
 ) : TestEventHandlerStrategyBase(agentOptions, controller) {
 	private val logger = getLogger(this)
 
 	@Throws(DumpException::class, CoverageGenerationException::class)
 	override fun testEnd(
 		test: String,
-		testExecution: TestExecution?
+		testExecution: TestExecution
 	): TestInfo? {
 		logger.debug("Test {} ended with execution {}. Writing exec file and test execution", test, testExecution)
 		super.testEnd(test, testExecution)
@@ -31,18 +31,16 @@ class CoverageToExecFileStrategy(
 		// Ensures that the coverage collected between the last test and the JVM shutdown
 		// is not considered a test with the same name as the last test
 		controller.resetSessionId()
-		if (testExecution != null) {
-			try {
-				testExecutionWriter?.append(testExecution)
-				logger.debug("Successfully wrote test execution for {}", test)
-			} catch (e: IOException) {
-				logger.error(
-					"Failed to append test execution for test '{}' to the testwise report: {}." +
-							" This test will be missing from the final report." +
-							" Check that the agent's 'out' directory is writable.",
-					test, e.message, e
-				)
-			}
+		try {
+			testExecutionWriter.append(testExecution)
+			logger.debug("Successfully wrote test execution for {}", test)
+		} catch (e: IOException) {
+			logger.error(
+				"Failed to append test execution for test '{}' to the testwise report: {}." +
+						" This test will be missing from the final report." +
+						" Check that the agent's 'out' directory is writable.",
+				test, e.message, e
+			)
 		}
 		return null
 	}

--- a/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/CoverageToJsonStrategyBase.kt
+++ b/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/CoverageToJsonStrategyBase.kt
@@ -65,12 +65,10 @@ abstract class CoverageToJsonStrategyBase(
 	@Throws(DumpException::class, CoverageGenerationException::class)
 	override fun testEnd(
 		test: String,
-		testExecution: TestExecution?
+		testExecution: TestExecution
 	): TestInfo? {
 		super.testEnd(test, testExecution)
-		if (testExecution != null) {
-			testExecutions.add(testExecution)
-		}
+		testExecutions.add(testExecution)
 
 		try {
 			if (testExecFile == null) {
@@ -86,6 +84,9 @@ abstract class CoverageToJsonStrategyBase(
 
 	@Throws(IOException::class, CoverageGenerationException::class)
 	override fun testRunEnd(partial: Boolean) {
+		// Ensures that a test for which we never received a valid /test/end request still shows up in the report
+		endRunningTestAsInconclusive("the test run ended")
+
 		if (testExecFile == null) {
 			logger.warn("Tried to end a test run that contained no tests!")
 			clearTestRun()

--- a/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/CoverageViaHttpStrategy.kt
+++ b/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/CoverageViaHttpStrategy.kt
@@ -12,8 +12,8 @@ import com.teamscale.report.testwise.model.builder.TestInfoBuilder
 
 /**
  * Strategy which directly converts the collected coverage into a JSON object in place and returns the result to the
- * caller as response to the http request. If a test execution is given it is merged into the representation and
- * returned together with the coverage.
+ * caller as response to the http request. The test execution is merged into the representation and returned together
+ * with the coverage.
  */
 class CoverageViaHttpStrategy(
 	controller: JacocoRuntimeController, agentOptions: AgentOptions,
@@ -22,16 +22,14 @@ class CoverageViaHttpStrategy(
 	private val logger = getLogger(this)
 
 	@Throws(DumpException::class, CoverageGenerationException::class)
-	override fun testEnd(test: String, testExecution: TestExecution?): TestInfo {
+	override fun testEnd(test: String, testExecution: TestExecution): TestInfo {
 		super.testEnd(test, testExecution)
 
 		val builder = TestInfoBuilder(test)
 		val dump = controller.dumpAndReset()
 		reportGenerator.updateClassDirCache()
 		reportGenerator.convert(dump)?.let { builder.setCoverage(it) }
-		if (testExecution != null) {
-			builder.setExecution(testExecution)
-		}
+		builder.setExecution(testExecution)
 		val testInfo = builder.build()
 		logger.debug("Generated test info {}", testInfo)
 		return testInfo

--- a/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/TestEventHandlerStrategyBase.kt
+++ b/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/TestEventHandlerStrategyBase.kt
@@ -30,25 +30,22 @@ abstract class TestEventHandlerStrategyBase protected constructor(
 	/** Uniform path of the test that is currently running, or null if no test is in progress.  */
 	private var runningTest: String? = null
 
+	/** Uniform path of the test that was ended last, or null if no test has ended yet.  */
+	private var lastEndedTest: String? = null
+
+	/**
+	 * The duration we derived for [lastEndedTest] from the time between its /test/start and /test/end requests, or null
+	 * if we could not derive one because we did not receive a matching /test/start request.
+	 */
+	private var lastEndedTestDurationMillis: Long? = null
+
 	/** May be null if the user did not configure Teamscale.  */
 	@JvmField
 	protected val teamscaleClient = agentOptions.createTeamscaleClient(true)
 
 	/** Called when test test with the given name is about to start.  */
 	open fun testStart(test: String) {
-		runningTest?.let { previousTest ->
-			logger.warn(
-				"Test '{}' was started while test '{}' was still running (no /test/end was received)." +
-						" Automatically ending the previous test '{}' using the time until the new test's start as its duration.",
-				test, previousTest, ETestExecutionResult.SKIPPED
-			)
-			testEnd(
-				previousTest, TestExecution(
-					previousTest, 0L, ETestExecutionResult.SKIPPED,
-					"The test did not end properly: a new test ('$test') was started before this test ended."
-				)
-			)
-		}
+		endRunningTestAsInconclusive("a new test ('$test') was started")
 		logger.debug("Test {} started", test)
 		// Reset coverage so that we only record coverage that belongs to this particular test case.
 		controller.reset()
@@ -61,27 +58,90 @@ abstract class TestEventHandlerStrategyBase protected constructor(
 	 * Called when the test with the given name finished.
 	 * 
 	 * @param test          Uniform path of the test
-	 * @param testExecution A test execution object holding the test result and error message. May be null if none is
-	 * given in the request.
+	 * @param testExecution A test execution object holding the test result and error message.
 	 * @return The body of the response. `null` indicates "204 No content". Non-null results will be treated
 	 * as a json response.
 	 */
 	@Throws(DumpException::class, CoverageGenerationException::class)
 	open fun testEnd(
 		test: String,
-		testExecution: TestExecution?
+		testExecution: TestExecution
 	): TestInfo? {
-		if (testExecution != null) {
-			testExecution.uniformPath = test
-			if (startTimestamp != -1L) {
-				val endTimestamp = System.currentTimeMillis()
-				@Suppress("DEPRECATION")
-				testExecution.durationMillis = endTimestamp - startTimestamp
-			}
+		testExecution.uniformPath = test
+		val derivedDurationMillis = deriveDurationMillis(test, testExecution)
+		derivedDurationMillis?.let {
+			@Suppress("DEPRECATION")
+			testExecution.durationMillis = it
 		}
+		lastEndedTest = test
+		lastEndedTestDurationMillis = derivedDurationMillis
 		runningTest = null
+		startTimestamp = -1
 		logger.debug("Test {} ended with test execution {}", test, testExecution)
 		return null
+	}
+
+	/**
+	 * Ends the test that is currently running, if any, as [ETestExecutionResult.INCONCLUSIVE]. We do not know its
+	 * actual result, since the profiler never received a valid /test/end request for it.
+	 *
+	 * @param cause Description of what ended the test, e.g. the start of another test. Used in the log message and
+	 * recorded as the test's message in the report.
+	 */
+	@Throws(DumpException::class, CoverageGenerationException::class)
+	protected fun endRunningTestAsInconclusive(cause: String) {
+		val test = runningTest ?: return
+		logger.warn(
+			"No valid /test/end request was received for test '{}' before {}." +
+					" Automatically ending it as '{}', using the time until now as its duration.",
+			test, cause, ETestExecutionResult.INCONCLUSIVE
+		)
+		val testInfo = testEnd(
+			test, TestExecution(
+				test, 0L, ETestExecutionResult.INCONCLUSIVE,
+				"The test did not end properly: $cause before this test ended."
+			)
+		)
+		if (testInfo != null) {
+			logger.warn(
+				"The coverage recorded for test '{}' is lost. The profiler is configured to return each test's" +
+						" coverage in the response to its /test/end request (tia-mode=http), but it never received a" +
+						" valid /test/end request for this test.", test
+			)
+		}
+	}
+
+	/**
+	 * Derives the duration of the given test from the time between its /test/start and its /test/end request. Returns
+	 * null if we cannot derive it, in which case the duration given by the caller (if any) is used as-is.
+	 */
+	private fun deriveDurationMillis(test: String, testExecution: TestExecution): Long? {
+		if (runningTest == test) return System.currentTimeMillis() - startTimestamp
+
+		if (test == lastEndedTest) {
+			// The test was already ended once, e.g. because the caller sent a second /test/end request for it. Reuse
+			// the duration derived back then instead of claiming that no /test/start request was received, which
+			// would be wrong and unactionable.
+			return lastEndedTestDurationMillis
+		}
+
+		if (!testExecution.hasExplicitDuration) logMissingDuration(test)
+		return null
+	}
+
+	/**
+	 * Logs that we can neither derive the duration of the given test ourselves, because we did not receive a matching
+	 * /test/start request, nor did the caller provide the duration in the /test/end request.
+	 */
+	private fun logMissingDuration(test: String) {
+		logger.warn(
+			"No /test/start request was received for test '{}', so the profiler could not derive its" +
+					" duration and none was provided in the /test/end request either." +
+					" The duration reported for this test will be inaccurate." +
+					" Please send a /test/start request before ending a test or provide a 'duration'" +
+					" (in seconds) in the body of the /test/end request.",
+			test
+		)
 	}
 
 	/**

--- a/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/TestEventHandlerStrategyBase.kt
+++ b/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/TestEventHandlerStrategyBase.kt
@@ -37,7 +37,7 @@ abstract class TestEventHandlerStrategyBase protected constructor(
 	 * The duration we derived for [lastEndedTest] from the time between its /test/start and /test/end requests, or null
 	 * if we could not derive one because we did not receive a matching /test/start request.
 	 */
-	private var lastEndedTestDurationMillis: Long? = null
+	private var lastEndedTestDurationSeconds: Double? = null
 
 	/** May be null if the user did not configure Teamscale.  */
 	@JvmField
@@ -68,13 +68,12 @@ abstract class TestEventHandlerStrategyBase protected constructor(
 		testExecution: TestExecution
 	): TestInfo? {
 		testExecution.uniformPath = test
-		val derivedDurationMillis = deriveDurationMillis(test, testExecution)
-		derivedDurationMillis?.let {
-			@Suppress("DEPRECATION")
-			testExecution.durationMillis = it
+		val derivedDurationSeconds = deriveDurationSeconds(test, testExecution)
+		derivedDurationSeconds?.let {
+			testExecution.durationSeconds = it
 		}
 		lastEndedTest = test
-		lastEndedTestDurationMillis = derivedDurationMillis
+		lastEndedTestDurationSeconds = derivedDurationSeconds
 		runningTest = null
 		startTimestamp = -1
 		logger.debug("Test {} ended with test execution {}", test, testExecution)
@@ -115,14 +114,14 @@ abstract class TestEventHandlerStrategyBase protected constructor(
 	 * Derives the duration of the given test from the time between its /test/start and its /test/end request. Returns
 	 * null if we cannot derive it, in which case the duration given by the caller (if any) is used as-is.
 	 */
-	private fun deriveDurationMillis(test: String, testExecution: TestExecution): Long? {
-		if (runningTest == test) return System.currentTimeMillis() - startTimestamp
+	private fun deriveDurationSeconds(test: String, testExecution: TestExecution): Double? {
+		if (runningTest == test) return (System.currentTimeMillis() - startTimestamp) / 1000.0
 
 		if (test == lastEndedTest) {
 			// The test was already ended once, e.g. because the caller sent a second /test/end request for it. Reuse
 			// the duration derived back then instead of claiming that no /test/start request was received, which
 			// would be wrong and unactionable.
-			return lastEndedTestDurationMillis
+			return lastEndedTestDurationSeconds
 		}
 
 		if (!testExecution.hasExplicitDuration) logMissingDuration(test)

--- a/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgent.kt
+++ b/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgent.kt
@@ -18,7 +18,7 @@ import kotlin.Throws
  */
 class TestwiseCoverageAgent(
 	options: AgentOptions,
-	testExecutionWriter: TestExecutionWriter?,
+	testExecutionWriter: TestExecutionWriter,
 	reportGenerator: JaCoCoTestwiseReportGenerator
 ) : AgentBase(options) {
 	/**

--- a/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageResource.kt
+++ b/agent/src/main/kotlin/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageResource.kt
@@ -4,6 +4,7 @@ import com.teamscale.client.ClusteredTestDetails
 import com.teamscale.jacoco.agent.JacocoRuntimeController.DumpException
 import com.teamscale.jacoco.agent.ResourceBase
 import com.teamscale.report.testwise.jacoco.cache.CoverageGenerationException
+import com.teamscale.report.testwise.model.ETestExecutionResult
 import com.teamscale.report.testwise.model.TestExecution
 import com.teamscale.report.testwise.model.TestInfo
 import java.io.IOException
@@ -31,7 +32,7 @@ class TestwiseCoverageResource(private val testwiseCoverageAgent: TestwiseCovera
 
 		logger.debug("Start test {}", testId)
 
-		testwiseCoverageAgent.testEventHandler.testStart(testId!!)
+		testwiseCoverageAgent.testEventHandler.testStart(testId)
 		return Response.noContent().build()
 	}
 
@@ -46,9 +47,20 @@ class TestwiseCoverageResource(private val testwiseCoverageAgent: TestwiseCovera
 	): TestInfo? {
 		if (testId.isNullOrEmpty()) handleBadRequest("Test name is missing!")
 
-		logger.debug("End test {}", testId)
+		if (testExecution?.result == null) {
+			// We reject the request without ending the test, i.e. without dumping and resetting the coverage.
+			// The caller needs to repeat the request with a result.
+			handleBadRequest(
+				"The test result is missing for test '$testId'!" +
+						" Please provide a JSON body containing a 'result' (one of $VALID_RESULTS)." +
+						" The test was not ended and its coverage is still being recorded," +
+						" so please repeat this request with a result." +
+						" If you don't, the test will be recorded as ${ETestExecutionResult.INCONCLUSIVE}" +
+						" once the next test starts or the test run ends."
+			)
+		}
 
-		return testwiseCoverageAgent.testEventHandler.testEnd(testId!!, testExecution)
+		return testwiseCoverageAgent.testEventHandler.testEnd(testId, testExecution)
 	}
 
 	/** Handles the start of a new testrun.  */
@@ -83,5 +95,8 @@ class TestwiseCoverageResource(private val testwiseCoverageAgent: TestwiseCovera
 	companion object {
 		/** Path parameter placeholder used in the HTTP requests.  */
 		private const val TEST_ID_PARAMETER = "testId"
+
+		/** The test results that callers may supply, for use in error messages.  */
+		private val VALID_RESULTS = ETestExecutionResult.entries.joinToString()
 	}
 }

--- a/agent/src/test/kotlin/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.kt
+++ b/agent/src/test/kotlin/com/teamscale/jacoco/agent/testimpact/CoverageToTeamscaleStrategyTest.kt
@@ -1,5 +1,9 @@
 package com.teamscale.jacoco.agent.testimpact
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.teamscale.client.*
 import com.teamscale.jacoco.agent.JacocoRuntimeController
 import com.teamscale.jacoco.agent.options.AgentOptions
@@ -20,6 +24,7 @@ import org.mockito.ArgumentMatchers.matches
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
+import org.slf4j.LoggerFactory
 import retrofit2.Response
 import java.io.File
 import java.io.IOException
@@ -67,7 +72,7 @@ class CoverageToTeamscaleStrategyTest {
 	/** Regression test for TS-46939. */
 	@Test
 	@Throws(Exception::class)
-	fun shouldAutomaticallyEndPreviousTestAsSkippedWhenNewTestStartsWithoutEnd() {
+	fun shouldAutomaticallyEndPreviousTestAsInconclusiveWhenNewTestStartsWithoutEnd() {
 		val options = mockOptions(false)
 		val strategy = CoverageToTeamscaleStrategy(controller, options, reportGenerator)
 
@@ -93,12 +98,157 @@ class CoverageToTeamscaleStrategyTest {
 		)
 		val report = reportCaptor.firstValue
 
-		assertThat(report).contains("\"uniformPath\":\"a\"", "\"result\":\"SKIPPED\"")
+		assertThat(report).contains("\"uniformPath\":\"a\"", "\"result\":\"INCONCLUSIVE\"")
 		assertThat(report).contains("\"uniformPath\":\"b\"", "\"result\":\"PASSED\"")
 		val durationA = Regex("\"uniformPath\":\"a\"[^}]*?\"duration\":([0-9.E-]+)")
 			.find(report)!!.groupValues[1].toDouble()
 		assertThat(durationA).isGreaterThan(0.0)
 	}
+
+	/**
+	 * A test that is still running when the test run ends must not be dropped from the report. This happens e.g. if we
+	 * rejected its /test/end request for not containing a result and the caller never repeated it.
+	 */
+	@Test
+	@Throws(Exception::class)
+	fun shouldEndARunningTestAsInconclusiveWhenTheTestRunEnds() {
+		val strategy = CoverageToTeamscaleStrategy(controller, mockOptions(false), reportGenerator)
+
+		whenever(reportGenerator.convert(any<File>())).thenReturn(getDummyTestwiseCoverage("a"))
+
+		// Test "a" is started but never ended.
+		strategy.testStart("a")
+		strategy.testRunEnd(false)
+
+		val reportCaptor = argumentCaptor<String>()
+		verify(client).uploadReport(
+			eq(EReportFormat.TESTWISE_COVERAGE),
+			reportCaptor.capture(),
+			anyOrNull(),
+			anyOrNull(),
+			anyOrNull(),
+			anyOrNull(),
+			anyOrNull()
+		)
+
+		assertThat(reportCaptor.firstValue).contains(
+			"\"uniformPath\":\"a\"", "\"result\":\"INCONCLUSIVE\"", "the test run ended"
+		)
+	}
+
+	/** We must not report the duration of a previous test as the duration of a test we never saw starting. */
+	@Test
+	@Throws(Exception::class)
+	fun shouldNotDeriveADurationForATestThatWasNeverStarted() {
+		val strategy = CoverageToTeamscaleStrategy(controller, mockOptions(false), reportGenerator)
+
+		strategy.testStart("a")
+		// Test "a" needs to take some time so that a duration wrongly derived for "b" would be non-zero.
+		Thread.sleep(5)
+		strategy.testEnd("a", TestExecution("a", 0L, ETestExecutionResult.PASSED))
+
+		val executionOfB = TestExecution("b", 0L, ETestExecutionResult.PASSED)
+		strategy.testEnd("b", executionOfB)
+
+		assertThat(executionOfB.durationSeconds).isEqualTo(0.0)
+	}
+
+	/**
+	 * A caller may end the same test twice, e.g. by repeating a /test/end request whose response it never received.
+	 * The duration we derived during the first request must survive that, since the repeated request usually contains
+	 * no duration either.
+	 */
+	@Test
+	@Throws(Exception::class)
+	fun shouldKeepTheDerivedDurationWhenATestIsEndedTwice() {
+		val strategy = CoverageToTeamscaleStrategy(controller, mockOptions(false), reportGenerator)
+
+		strategy.testStart("mytest")
+		// The test needs to take some time so that we can assert that its duration is non-zero.
+		Thread.sleep(5)
+		val firstExecution = TestExecution("mytest", 0L, ETestExecutionResult.PASSED)
+		strategy.testEnd("mytest", firstExecution)
+
+		val repeatedExecution = TestExecution("mytest", 0L, ETestExecutionResult.PASSED)
+		strategy.testEnd("mytest", repeatedExecution)
+
+		assertThat(repeatedExecution.durationSeconds)
+			.isGreaterThan(0.0)
+			.isEqualTo(firstExecution.durationSeconds)
+	}
+
+	@Test
+	fun shouldNotWarnAboutAMissingTestStartWhenATestIsEndedTwice() {
+		val log = captureLog {
+			it.testStart("mytest")
+			it.testEnd("mytest", TestExecution("mytest", 0L, ETestExecutionResult.PASSED))
+			it.testEnd("mytest", TestExecution("mytest", 0L, ETestExecutionResult.PASSED))
+		}
+
+		assertThat(log.messagesAt(Level.WARN)).noneSatisfy {
+			assertThat(it).contains("/test/start")
+		}
+	}
+
+	@Test
+	fun shouldWarnWhenNoTestStartWasReceived() {
+		val log = captureLog {
+			it.testEnd("mytest", TestExecution("mytest", 0L, ETestExecutionResult.PASSED))
+		}
+
+		assertThat(log.messagesAt(Level.WARN)).anySatisfy {
+			assertThat(it).contains("No /test/start request was received for test 'mytest'")
+		}
+	}
+
+	@Test
+	fun shouldNotWarnAboutTheDurationIfTheCallerProvidedOne() {
+		val log = captureLog {
+			it.testEnd("mytest", TestExecution("mytest", 1500L, ETestExecutionResult.PASSED))
+		}
+
+		assertThat(log.messagesAt(Level.WARN)).noneSatisfy {
+			assertThat(it).contains("/test/start")
+		}
+	}
+
+	@Test
+	fun shouldNotWarnAboutTheDurationIfTheCallerExplicitlyReportedZeroDuration() {
+		val execution = JsonUtils.deserialize<TestExecution>(
+			"""{"uniformPath":"mytest","result":"SKIPPED","duration":0}"""
+		)
+
+		val log = captureLog { it.testEnd("mytest", execution) }
+
+		assertThat(log.messagesAt(Level.WARN)).noneSatisfy {
+			assertThat(it).contains("/test/start")
+		}
+	}
+
+	/** Runs the given actions against a strategy and returns the events it logged. */
+	private fun captureLog(action: (CoverageToTeamscaleStrategy) -> Unit): List<ILoggingEvent> {
+		val strategy = CoverageToTeamscaleStrategy(controller, mockOptions(false), reportGenerator)
+		val logger = LoggerFactory.getLogger(strategy.javaClass) as Logger
+		val appender = ListAppender<ILoggingEvent>().apply { start() }
+		val previousLevel = logger.level
+		logger.level = Level.DEBUG
+		logger.addAppender(appender)
+		val events = try {
+			action(strategy)
+			appender.list.toList()
+		} finally {
+			logger.detachAppender(appender)
+			logger.level = previousLevel
+			appender.stop()
+		}
+		assertThat(events)
+			.describedAs("The strategy must have logged something, otherwise we are not capturing its log events")
+			.isNotEmpty()
+		return events
+	}
+
+	private fun List<ILoggingEvent>.messagesAt(level: Level) =
+		filter { it.level == level }.map { it.formattedMessage }
 
 	@ParameterizedTest
 	@ValueSource(booleans = [true, false])

--- a/agent/src/test/kotlin/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.kt
+++ b/agent/src/test/kotlin/com/teamscale/jacoco/agent/testimpact/TestwiseCoverageAgentTest.kt
@@ -4,15 +4,21 @@ import com.teamscale.client.*
 import com.teamscale.jacoco.agent.options.AgentOptions
 import com.teamscale.jacoco.agent.options.ETestwiseCoverageMode
 import com.teamscale.jacoco.agent.util.TestUtils
+import com.teamscale.report.jacoco.dump.Dump
 import com.teamscale.report.testwise.jacoco.JaCoCoTestwiseReportGenerator
 import com.teamscale.report.testwise.model.ETestExecutionResult
+import com.teamscale.report.testwise.model.TestExecution
+import com.teamscale.tia.client.ITestwiseCoverageAgentApi
 import com.teamscale.tia.client.TestRun
 import com.teamscale.tia.client.TiaAgent
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
@@ -25,6 +31,7 @@ import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.http.POST
+import retrofit2.http.Path
 import retrofit2.http.Query
 import java.io.File
 
@@ -39,6 +46,9 @@ class TestwiseCoverageAgentTest {
 
 	@TempDir
 	lateinit var tempDir: File
+
+	/** The agents started during the current test. Their HTTP servers must be stopped again, cf. [stopAgents]. */
+	private val agents = mutableListOf<TestwiseCoverageAgent>()
 
 	@Test
 	@Throws(Exception::class)
@@ -65,16 +75,7 @@ class TestwiseCoverageAgentTest {
 			CoverageToTeamscaleStrategyTest.getDummyTestwiseCoverage("test2")
 		)
 
-		val port: Int
-		synchronized(TestUtils::class.java) {
-			port = TestUtils.freePort
-			val options = mockOptions(port)
-			whenever(options.createNewFileInOutputDirectory(anyOrNull(), anyOrNull()))
-				.thenReturn(File(tempDir, "test"))
-			TestwiseCoverageAgent(options, null, reportGenerator)
-		}
-
-		val agent = TiaAgent(false, "http://localhost:$port".toHttpUrl())
+		val agent = TiaAgent(false, startAgent(dumpsCoverage = true))
 
 		val testRun = agent.startTestRun(availableTests)
 		assertThat(testRun.prioritizedClusters).hasSize(1)
@@ -99,6 +100,131 @@ class TestwiseCoverageAgentTest {
 		)
 	}
 
+	/** The test result is mandatory, so a /test/end request without a body must be rejected. */
+	@Test
+	@Throws(Exception::class)
+	fun shouldRejectATestEndRequestWithoutABody() {
+		val url = startAgent()
+		ITestwiseCoverageAgentApi.createService(url).testStarted("test1").execute()
+
+		val response = apiWithoutBody(url).testFinished("test1").execute()
+
+		assertThat(response.code()).isEqualTo(400)
+		assertThat(response.errorBody()!!.string()).contains("The test result is missing for test 'test1'")
+	}
+
+	/** The test result is mandatory, so a /test/end request whose body has no result must be rejected. */
+	@Test
+	@Throws(Exception::class)
+	fun shouldRejectATestEndRequestWithoutAResult() {
+		val api = ITestwiseCoverageAgentApi.createService(startAgent())
+		api.testStarted("test1").execute()
+
+		val response = api.testFinished("test1", TestExecution(uniformPath = "test1")).execute()
+
+		assertThat(response.code()).isEqualTo(400)
+		assertThat(response.errorBody()!!.string()).contains("The test result is missing for test 'test1'")
+	}
+
+	/**
+	 * In tia-mode=http, a test's coverage is only handed to the caller in the response to its /test/end request.
+	 * Rejecting such a request must therefore not dump and discard the coverage: the caller must receive it when it
+	 * repeats the request with a result.
+	 */
+	@Test
+	@Throws(Exception::class)
+	fun shouldNotDiscardTheCoverageWhenRejectingATestEndRequestInHttpMode() {
+		whenever(reportGenerator.convert(any<Dump>())).thenReturn(
+			CoverageToTeamscaleStrategyTest.getDummyTestCoverage("test1")
+		)
+		val url = startAgent(mode = ETestwiseCoverageMode.HTTP)
+		val api = ITestwiseCoverageAgentApi.createService(url)
+
+		api.testStarted("test1").execute()
+		val rejectedResponse = apiWithoutBody(url).testFinished("test1").execute()
+
+		assertThat(rejectedResponse.code()).isEqualTo(400)
+		// the coverage must still be recorded, i.e. it must neither have been dumped nor discarded
+		verify(reportGenerator, never()).convert(any<Dump>())
+
+		val response = api.testFinished("test1", TestExecution("test1", 0L, ETestExecutionResult.PASSED)).execute()
+
+		assertThat(response.isSuccessful).describedAs(response.toString()).isTrue()
+		assertThat(response.body()!!.string()).contains(
+			"\"uniformPath\":\"test1\"", "\"result\":\"PASSED\"", "\"fileName\":\"Main.java\""
+		)
+	}
+
+	/**
+	 * A caller that reacts to the rejection of its /test/end request by repeating it with a result must end up with the
+	 * correct result and the duration the profiler derived for the test.
+	 */
+	@Test
+	@Throws(Exception::class)
+	fun shouldRecordTheRepeatedTestEndRequestAfterRejectingTheFirstOne() {
+		whenever(reportGenerator.convert(any<File>())).thenReturn(
+			CoverageToTeamscaleStrategyTest.getDummyTestwiseCoverage("test1")
+		)
+		val url = startAgent(dumpsCoverage = true)
+		val api = ITestwiseCoverageAgentApi.createService(url)
+
+		api.testStarted("test1").execute()
+		// The test needs to take some time so that we can assert that its duration is non-zero.
+		Thread.sleep(5)
+		apiWithoutBody(url).testFinished("test1").execute()
+		// The caller reacts to the rejection by repeating the request with a result, but without a duration.
+		api.testFinished("test1", TestExecution("test1", 0L, ETestExecutionResult.PASSED)).execute()
+		api.testRunFinished(true).execute()
+
+		val report = argumentCaptor<String>()
+		verify(client).uploadReport(
+			eq(EReportFormat.TESTWISE_COVERAGE), report.capture(),
+			anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
+		)
+		assertThat(report.firstValue)
+			.contains("\"result\":\"PASSED\"")
+			// the rejected request must not have caused a result of its own to be recorded
+			.doesNotContain("INCONCLUSIVE")
+		val duration = Regex("\"uniformPath\":\"test1\"[^}]*?\"duration\":([0-9.E-]+)")
+			.find(report.firstValue)!!.groupValues[1].toDouble()
+		assertThat(duration).isGreaterThan(0.0)
+	}
+
+	/**
+	 * Starts an agent in testwise coverage mode and returns the URL its HTTP server listens on. The agent is shut down
+	 * again after the test, cf. [stopAgents].
+	 *
+	 * @param dumpsCoverage whether the test ends a test, which makes the agent write an exec file.
+	 * @param mode the tia-mode to configure for the agent.
+	 */
+	private fun startAgent(
+		dumpsCoverage: Boolean = false,
+		mode: ETestwiseCoverageMode = ETestwiseCoverageMode.TEAMSCALE_UPLOAD
+	): HttpUrl {
+		val port: Int
+		synchronized(TestUtils::class.java) {
+			port = TestUtils.freePort
+			val options = mockOptions(port, mode)
+			if (dumpsCoverage) {
+				whenever(options.createNewFileInOutputDirectory(anyOrNull(), anyOrNull()))
+					.thenReturn(File(tempDir, "test"))
+			}
+			val testExecutionWriter = TestExecutionWriter(File(tempDir, "test-execution.json"))
+			agents.add(TestwiseCoverageAgent(options, testExecutionWriter, reportGenerator))
+		}
+		return "http://localhost:$port".toHttpUrl()
+	}
+
+	/**
+	 * Shuts down the HTTP servers of all agents started during the test. Otherwise, each test would leave a listening
+	 * socket and its request handling threads behind for the rest of the test JVM's lifetime.
+	 */
+	@AfterEach
+	fun stopAgents() {
+		agents.forEach { it.stopServer() }
+		agents.clear()
+	}
+
 	@Test
 	@Throws(Exception::class)
 	fun testErrorHandling() {
@@ -110,14 +236,7 @@ class TestwiseCoverageAgentTest {
 			)
 		).thenReturn(Response.error(403, errorBody))
 
-		val port: Int
-		synchronized(TestUtils::class.java) {
-			port = TestUtils.freePort
-			val options = mockOptions(port)
-			TestwiseCoverageAgent(options, null, reportGenerator)
-		}
-
-		val agent = TiaAgent(false, "http://localhost:$port".toHttpUrl())
+		val agent = TiaAgent(false, startAgent())
 		assertThatCode { agent.startTestRunAssumingUnchangedTests() }
 			.hasMessageContaining(MISSING_VIEW_PERMISSIONS)
 	}
@@ -132,7 +251,23 @@ class TestwiseCoverageAgentTest {
 			@Query("include-non-impacted") includeNonImpacted: Boolean,
 			@Query("baseline") baseline: Long?
 		): Call<List<PrioritizableTestCluster>>
+
+		/**
+		 * Version of test/end that doesn't have a body. This can't be triggered via the Java TIA client anymore, but
+		 * other clients may still send such a request, which the agent must reject.
+		 */
+		@POST("test/end/{testUniformPath}")
+		fun testFinished(
+			@Path(value = "testUniformPath", encoded = true) testUniformPath: String
+		): Call<ResponseBody>
 	}
+
+	/** Creates an API for requests that the Java TIA client cannot send, e.g. because they have no body. */
+	private fun apiWithoutBody(url: HttpUrl) = Retrofit.Builder()
+		.addConverterFactory(JacksonConverterFactory.create())
+		.baseUrl(url)
+		.build()
+		.create(ITestwiseCoverageAgentApiWithoutBody::class.java)
 
 	@Test
 	@Throws(Exception::class)
@@ -151,19 +286,7 @@ class TestwiseCoverageAgentTest {
 			)
 		).thenReturn(Response.success(impactedClusters))
 
-		val port: Int
-		synchronized(TestUtils::class.java) {
-			port = TestUtils.freePort
-			TestwiseCoverageAgent(mockOptions(port), null, reportGenerator)
-		}
-
-		val api = Retrofit.Builder()
-			.addConverterFactory(JacksonConverterFactory.create())
-			.baseUrl("http://localhost:$port")
-			.build()
-			.create(ITestwiseCoverageAgentApiWithoutBody::class.java)
-
-		val response = api.testRunStarted(false, null).execute()
+		val response = apiWithoutBody(startAgent()).testRunStarted(false, null).execute()
 
 		assertThat(response.isSuccessful).describedAs(response.toString()).isTrue()
 		val tests = response.body()
@@ -171,7 +294,7 @@ class TestwiseCoverageAgentTest {
 		assertThat(tests!![0].tests).hasSize(1)
 	}
 
-	private fun mockOptions(port: Int): AgentOptions {
+	private fun mockOptions(port: Int, mode: ETestwiseCoverageMode = ETestwiseCoverageMode.TEAMSCALE_UPLOAD): AgentOptions {
 		val options = mock<AgentOptions>()
 		whenever(options.createTeamscaleClient(true)).thenReturn(client)
 
@@ -186,10 +309,9 @@ class TestwiseCoverageAgentTest {
 		options.apply {
 			teamscaleServer = server
 			httpServerPort = port
-			testwiseCoverageMode = ETestwiseCoverageMode.TEAMSCALE_UPLOAD
+			testwiseCoverageMode = mode
 		}
 
-		whenever(options.createTeamscaleClient(true)).thenReturn(client)
 		return options
 	}
 

--- a/impacted-test-engine/src/main/kotlin/com/teamscale/test_impacted/engine/executor/TeamscaleAgentNotifier.kt
+++ b/impacted-test-engine/src/main/kotlin/com/teamscale/test_impacted/engine/executor/TeamscaleAgentNotifier.kt
@@ -38,16 +38,11 @@ open class TeamscaleAgentNotifier(
 	}
 
 	/** Reports the end of a test to the Teamscale JaCoCo agent.  */
-	open fun endTest(testUniformPath: String, testExecution: TestExecution?) {
-		LOG.fine { "Ending test notification for: $testUniformPath (execution: ${testExecution != null})" }
+	open fun endTest(testUniformPath: String, testExecution: TestExecution) {
+		LOG.fine { "Ending test notification for: $testUniformPath (result: ${testExecution.result})" }
 		try {
 			testwiseCoverageAgentApis.forEach { apiService ->
-				val url = testUniformPath.encodeUrl()
-				if (testExecution == null) {
-					apiService.testFinished(url).execute()
-				} else {
-					apiService.testFinished(url, testExecution).execute()
-				}
+				apiService.testFinished(testUniformPath.encodeUrl(), testExecution).execute()
 			}
 			LOG.fine { "Successfully notified test end for: $testUniformPath" }
 		} catch (e: IOException) {

--- a/impacted-test-engine/src/main/kotlin/com/teamscale/test_impacted/engine/executor/TestwiseCoverageCollectingExecutionListener.kt
+++ b/impacted-test-engine/src/main/kotlin/com/teamscale/test_impacted/engine/executor/TestwiseCoverageCollectingExecutionListener.kt
@@ -84,9 +84,7 @@ class TestwiseCoverageCollectingExecutionListener(
 			val testExecution = getTestExecution(
 				testDescriptor, testExecutionResult, uniformPath
 			)
-			if (testExecution != null) {
-				testExecutions.add(testExecution)
-			}
+			testExecutions.add(testExecution)
 			teamscaleAgentNotifier.endTest(uniformPath, testExecution)
 		} else if (testDescriptor.parent.isPresent) {
 			val testExecutionResults = testResultCache.computeIfAbsent(
@@ -102,7 +100,7 @@ class TestwiseCoverageCollectingExecutionListener(
 		testDescriptor: TestDescriptor,
 		testExecutionResult: TestExecutionResult,
 		testUniformPath: String
-	): TestExecution? {
+	): TestExecution {
 		val testExecutionResults = getTestExecutionResults(testDescriptor, testExecutionResult)
 
 		val executionEndTime = System.currentTimeMillis()
@@ -141,20 +139,18 @@ class TestwiseCoverageCollectingExecutionListener(
 		duration: Long,
 		status: TestExecutionResult.Status,
 		message: String
-	): TestExecution? {
-		when (status) {
-			TestExecutionResult.Status.SUCCESSFUL -> return TestExecution(
-				testUniformPath, duration, ETestExecutionResult.PASSED
-			)
+	) = when (status) {
+		TestExecutionResult.Status.SUCCESSFUL -> TestExecution(
+			testUniformPath, duration, ETestExecutionResult.PASSED
+		)
 
-			TestExecutionResult.Status.ABORTED -> return TestExecution(
-				testUniformPath, duration, ETestExecutionResult.ERROR, message
-			)
+		TestExecutionResult.Status.ABORTED -> TestExecution(
+			testUniformPath, duration, ETestExecutionResult.ERROR, message
+		)
 
-			TestExecutionResult.Status.FAILED -> return TestExecution(
-				testUniformPath, duration, ETestExecutionResult.FAILURE, message
-			)
-		}
+		TestExecutionResult.Status.FAILED -> TestExecution(
+			testUniformPath, duration, ETestExecutionResult.FAILURE, message
+		)
 	}
 
 	/** Extracts the stacktrace from the given [Throwable] into a string or returns null if no throwable is given.  */

--- a/report-generator/src/main/kotlin/com/teamscale/report/testwise/model/ETestExecutionResult.kt
+++ b/report-generator/src/main/kotlin/com/teamscale/report/testwise/model/ETestExecutionResult.kt
@@ -32,5 +32,8 @@ enum class ETestExecutionResult {
 	FAILURE,
 
 	/** Caused by an error during test execution (e.g. exception thrown in the test runner code, not the test itself).  */
-	ERROR
+	ERROR,
+
+	/** The test was executed, but its actual result is ambiguous. */
+	INCONCLUSIVE
 }

--- a/report-generator/src/main/kotlin/com/teamscale/report/testwise/model/TestExecution.kt
+++ b/report-generator/src/main/kotlin/com/teamscale/report/testwise/model/TestExecution.kt
@@ -18,6 +18,7 @@
 package com.teamscale.report.testwise.model
 
 import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.io.Serializable
 
@@ -48,4 +49,12 @@ data class TestExecution @JvmOverloads constructor(
 	val durationSeconds: Double
 		@Suppress("DEPRECATION")
 		get() = duration ?: (durationMillis / 1000.0)
+
+	/**
+	 * Whether the caller explicitly provided a duration. A [durationMillis] of zero counts as no duration, since it is
+	 * indistinguishable from the default of that deprecated field. Use [duration] to report a duration of zero.
+	 */
+	@get:JsonIgnore
+	val hasExplicitDuration: Boolean
+		get() = duration != null || durationSeconds != 0.0
 }

--- a/report-generator/src/main/kotlin/com/teamscale/report/testwise/model/TestExecution.kt
+++ b/report-generator/src/main/kotlin/com/teamscale/report/testwise/model/TestExecution.kt
@@ -44,11 +44,18 @@ data class TestExecution @JvmOverloads constructor(
 	/** Duration of the execution in seconds. */
 	@JsonProperty("duration")
 	@JsonAlias("durationSeconds")
-	private val duration: Double? = null
+	private var duration: Double? = null
 
-	val durationSeconds: Double
+	/**
+	 * Duration of the execution in seconds. Falls back to the deprecated [durationMillis] if the caller did not provide
+	 * a duration in seconds.
+	 */
+	var durationSeconds: Double
 		@Suppress("DEPRECATION")
 		get() = duration ?: (durationMillis / 1000.0)
+		set(value) {
+			duration = value
+		}
 
 	/**
 	 * Whether the caller explicitly provided a duration. A [durationMillis] of zero counts as no duration, since it is

--- a/tia-client/src/main/kotlin/com/teamscale/tia/client/ITestwiseCoverageAgentApi.kt
+++ b/tia-client/src/main/kotlin/com/teamscale/tia/client/ITestwiseCoverageAgentApi.kt
@@ -37,12 +37,6 @@ interface ITestwiseCoverageAgentApi {
 	/** Test finished.  */
 	@POST("test/end/{testUniformPath}")
 	fun testFinished(
-		@Path(value = "testUniformPath", encoded = true) testUniformPath: String
-	): Call<ResponseBody>
-
-	/** Test finished.  */
-	@POST("test/end/{testUniformPath}")
-	fun testFinished(
 		@Path(value = "testUniformPath", encoded = true) testUniformPath: String,
 		@Body testExecution: TestExecution
 	): Call<ResponseBody>


### PR DESCRIPTION
Addresses issue [TS-47301](https://cqse.atlassian.net/browse/TS-47301)

- [ ] Changes are tested adequately
- [ ] Teamscale documentation updated in case of user-visible changes
- [ ] CHANGELOG.md updated
- [ ] Present new features in [N&N](https://cqse.atlassian.net/l/cp/KHSr81m1)
- [ ] [TGA Tutorial](https://docs.teamscale.com/tutorial/setting-up-tga-java) updated
- [ ] [TIA Tutorial](https://docs.teamscale.com/tutorial/tia-java/) updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.

